### PR TITLE
change links from data-lessons to datacarpentry

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,8 +29,8 @@ be taught over two full days of instruction.
 
 | Lesson    | Overview |
 | ------- | ---------- |
-| [Data Organization in Spreadsheets](https://data-lessons.github.io/spreadsheets-socialsci/) | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. |
-| [Data Cleaning with OpenRefine](https://data-lessons.github.io/openrefine-socialsci/) | Explore, summarize, and clean tabular data reproducibly. |
-| [Data Analysis and Vizualization with R](https://github.com/data-lessons/r-socialsci) | Import data into R, calculate summary statistics, and create publication-quality graphics.|
-| [Data Analysis and Vizualization with Python](https://data-lessons.github.io/python-socialsci/) | Import data into Python, calculate summary statistics, and create publication-quality graphics.|
-| [Data Management with SQL](https://data-lessons.github.io/sql-socialsci/) | Extract information from relational databases. |
+| [Data Organization in Spreadsheets](https://datacarpentry.github.io/spreadsheets-socialsci/) | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. |
+| [Data Cleaning with OpenRefine](https://datacarpentry.github.io/openrefine-socialsci/) | Explore, summarize, and clean tabular data reproducibly. |
+| [Data Analysis and Vizualization with R](https://datacarpentry.github.io/r-socialsci) | Import data into R, calculate summary statistics, and create publication-quality graphics.|
+| [Data Analysis and Vizualization with Python](https://datacarpentry.github.io/python-socialsci/) | Import data into Python, calculate summary statistics, and create publication-quality graphics.|
+| [Data Management with SQL](https://datacarpentry.github.io/sql-socialsci/) | Extract information from relational databases. |


### PR DESCRIPTION
Repos have been moved from data-lessons organization to datacarpentry. Update links.
