### PR TITLE
Update to styles v9.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .sass-cache
 __pycache__
 _site
+.Rproj.user
+.Rhistory
+.RData
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: "Contributor Code of Conduct"
-permalink: /conduct/
 ---
 As contributors and maintainers of this project,
 we pledge to follow the [Carpentry Code of Conduct][coc].

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
 JEKYLL=jekyll
+JEKYLL_VERSION=3.7.3
 PARSER=bin/markdown_ast.rb
 DST=_site
 
@@ -15,6 +16,10 @@ all : commands
 ## commands         : show all commands.
 commands :
 	@grep -h -E '^##' ${MAKEFILES} | sed -e 's/## //g'
+
+## docker-serve     : use docker to build the site
+docker-serve :
+	docker run --rm -it -v ${PWD}:/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll:${JEKYLL_VERSION} make serve
 
 ## serve            : run a local server.
 serve : lesson-md
@@ -63,7 +68,7 @@ RMD_DST = $(patsubst _episodes_rmd/%.Rmd,_episodes/%.md,$(RMD_SRC))
 # Lesson source files in the order they appear in the navigation menu.
 MARKDOWN_SRC = \
   index.md \
-  CONDUCT.md \
+  CODE_OF_CONDUCT.md \
   setup.md \
   $(sort $(wildcard _episodes/*.md)) \
   reference.md \
@@ -88,16 +93,16 @@ ${RMD_DST} : ${RMD_SRC}
 	@bin/knit_lessons.sh ${RMD_SRC}
 
 ## lesson-check     : validate lesson Markdown.
-lesson-check :
+lesson-check : lesson-fixme
 	@bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md
 
 ## lesson-check-all : validate lesson Markdown, checking line lengths and trailing whitespace.
 lesson-check-all :
-	@bin/lesson_check.py -s . -p ${PARSER} -l -w --permissive
+	@bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md -l -w --permissive
 
 ## unittest         : run unit tests on checking tools.
 unittest :
-	python bin/test_lesson_check.py
+	@bin/test_lesson_check.py
 
 ## lesson-files     : show expected names of generated files for debugging.
 lesson-files :

--- a/_config.yml
+++ b/_config.yml
@@ -2,14 +2,16 @@
 # Values for this lesson.
 #------------------------------------------------------------
 
-# Which carpentry is this ("swc", "dc", or "lc")?
+# Which carpentry is this ("swc", "dc", "lc", or "cp")?
+# swc: Software Carpentry
+# dc: Data Carpentry
+# lc: Library Carpentry
+# cp: Carpentries (to use for instructor traning for instance)
 carpentry: "dc"
 
 # Overall title for pages.
 title: "Social Sciences Workshop"
 
-# Contact.
-email: "lessons@software-carpentry.org"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
@@ -20,21 +22,28 @@ kind: "lesson"
 
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
+# Please don't change it: <USERNAME>/<PROJECT> is correct.
 repository: <USERNAME>/<PROJECT>
+
+# Email address, no mailto:
+email: "team@carpentries.org"
 
 # Sites.
 amy_site: "https://amy.software-carpentry.org/workshops"
+carpentries_github: "https://github.com/carpentries"
+carpentries_pages: "https://carpentries.github.io"
+carpentries_site: "https://carpentries.org/"
 dc_site: "http://datacarpentry.org"
-swc_github: "https://github.com/swcarpentry"
-swc_site: "https://software-carpentry.org"
-swc_pages: "https://swcarpentry.github.io"
-lc_site: "http://librarycarpentry.github.io/"
-template_repo: "https://github.com/carpentries/styles"
 example_repo: "https://github.com/carpentries/lesson-example"
 example_site: "https://carpentries.github.io/lesson-example"
+lc_site: "https://librarycarpentry.github.io/"
+swc_github: "https://github.com/swcarpentry"
+swc_pages: "https://swcarpentry.github.io"
+swc_site: "https://software-carpentry.org"
+template_repo: "https://github.com/carpentries/styles"
+training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
-training_site: "https://carpentries.github.io/instructor-training"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="
@@ -48,24 +57,34 @@ start_time: 0
 collections:
   episodes:
     output: true
-    permalink: /:path/
+    permalink: /:path/index.html
   extras:
     output: true
+    permalink: /:path/index.html
 
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:
-      root: ..
+      root: .
+      layout: page
   - scope:
       path: ""
       type: episodes
     values:
+      root: ..
       layout: episode
+  - scope:
+      path: ""
+      type: extras
+    values:
+      root: ..
+      layout: page
 
 # Files and directories that are not to be copied.
 exclude:
   - Makefile
-  - bin
+  - bin/
+  - .Rproj.user/
 
-# Turn off built-in syntax highlighting.
-highlighter: false
+# Turn on built-in syntax highlighting.
+highlighter: rouge

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -44,8 +44,8 @@
   </div>
   <div class="row">
     <div class="col-md-12" align="center">
-      Using <a href="https://github.com/swcarpentry/styles/">The Carpentries style</a> 
-      version <a href="https://github.com/swcarpentry/styles/releases/tag/v9.4.0">9.4.0</a>.
+      Using <a href="https://github.com/carpentries/styles/">The Carpentries style</a>
+      version <a href="https://github.com/carpentries/styles/releases/tag/v9.5.2">9.5.2</a>.
     </div>
   </div>
 </footer>

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -9,7 +9,8 @@
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint
 [cran-knitr]: https://cran.r-project.org/package=knitr
 [cran-stringr]: https://cran.r-project.org/package=stringr
-[email]: mailto:lessons@software-carpentry.org
+[dc-lessons]: http://www.datacarpentry.org/lessons/
+[email]: mailto:team@carpentries.org
 [github-importer]: https://import.github.com/
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/
@@ -17,7 +18,8 @@
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
-[lesson-example]: https://swcarpentry.github.io/lesson-example/
+[lc-lessons]: https://librarycarpentry.org/#portfolio
+[lesson-example]: https://carpentries.github.io/lesson-example/
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
 [numfocus]: https://numfocus.org/
@@ -31,7 +33,8 @@
 [ruby-install-guide]: https://www.ruby-lang.org/en/downloads/
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
-[styles]: https://github.com/swcarpentry/styles/
+[styles]: https://github.com/carpentries/styles/
+[swc-lessons]: https://software-carpentry.org/lessons/ 
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -38,7 +38,7 @@
       <ul class="nav navbar-nav">
 
 	{% comment %} Always show code of conduct. {% endcomment %}
-        <li><a href="{{ page.root }}{% link CONDUCT.md %}">Code of Conduct</a></li>
+        <li><a href="{{ page.root }}{% link CODE_OF_CONDUCT.md %}">Code of Conduct</a></li>
 
         {% if site.kind == "lesson" %}
 	{% comment %} Show setup instructions. {% endcomment %}

--- a/aio.md
+++ b/aio.md
@@ -1,6 +1,4 @@
 ---
-layout: page 
-permalink: /aio/
 ---
 <script>
   window.onload = function() {

--- a/bin/boilerplate/.travis.yml
+++ b/bin/boilerplate/.travis.yml
@@ -1,3 +1,4 @@
+# dist: trusty  # Ubuntu 14.04
 language: python
 python: 3.6
 branches:
@@ -5,10 +6,18 @@ branches:
   - gh-pages
   - /.*/
 before_install:
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+  - echo "deb https://cran.rstudio.com/bin/linux/ubuntu trusty/" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -y
+  - sudo apt-get install -y r-base
+  - sudo Rscript -e "install.packages('knitr', repos = 'https://', dependencies = TRUE)"
+  - sudo Rscript -e "install.packages('stringr', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
+  - sudo Rscript -e "install.packages('checkpoint', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
+  - sudo Rscript -e "install.packages('ggplot2', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - rvm default
-  - gem install json kramdown
+  - gem install json kramdown jekyll
 install:
   - pip install pyyaml
 script:
-  - make lesson-check
   - make lesson-check-all
+  - make --always-make site

--- a/bin/boilerplate/CODE_OF_CONDUCT.md
+++ b/bin/boilerplate/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: "Contributor Code of Conduct"
+---
+As contributors and maintainers of this project,
+we pledge to follow the [Carpentry Code of Conduct][coc].
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by following our [reporting guidelines][coc-reporting].
+
+{% include links.md %}

--- a/bin/boilerplate/CONTRIBUTING.md
+++ b/bin/boilerplate/CONTRIBUTING.md
@@ -15,7 +15,7 @@ In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
 Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+agrees to abide by our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 
@@ -50,19 +50,19 @@ and to meet some of our community members.
     which can be viewed at <https://swcarpentry.github.io/FIXME>.
 
 2.  If you wish to change the example lesson,
-    please work in <https://github.com/swcarpentry/lesson-example>,
+    please work in <https://github.com/carpentries/lesson-example>,
     which documents the format of our lessons
-    and can be viewed at <https://swcarpentry.github.io/lesson-example>.
+    and can be viewed at <https://carpentries.github.io/lesson-example>.
 
 3.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/swcarpentry/workshop-template>.
+    please work in <https://github.com/carpentries/workshop-template>.
     The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://swcarpentry.github.io/workshop-template>
+    while the extra pages in <https://carpentries.github.io/workshop-template>
     provide more background on our design choices.
 
 4.  If you wish to change CSS style files, tools,
     or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/swcarpentry/styles>.
+    please work in <https://github.com/carpentries/styles>.
 
 ## What to Contribute
 

--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -25,4 +25,4 @@ A list of contributors to the lesson can be found in [AUTHORS](AUTHORS)
 
 To cite this lesson, please consult with [CITATION](CITATION)
 
-[lesson-example]: https://swcarpentry.github.io/lesson-example
+[lesson-example]: https://carpentries.github.io/lesson-example

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -2,16 +2,15 @@
 # Values for this lesson.
 #------------------------------------------------------------
 
-# Which carpentry is this ("swc", "dc", or "lc")?
+# Which carpentry is this ("swc", "dc", "lc", or "cp")?
+# swc: Software Carpentry
+# dc: Data Carpentry
+# lc: Library Carpentry
+# cp: Carpentries (to use for instructor traning for instance)
 carpentry: "swc"
 
 # Overall title for pages.
 title: "Lesson Title"
-
-# Contact.  This *must* include the protocol: if it's an email
-# address, it must look like "mailto:lessons@software-carpentry.org",
-# or if it's a URL, "https://gitter.im/username/ProjectName".
-email: "mailto:lessons@software-carpentry.org"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
@@ -22,7 +21,11 @@ kind: "lesson"
 
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
+# Please don't change it: <USERNAME>/<PROJECT> is correct.
 repository: <USERNAME>/<PROJECT>
+
+# Email address, no mailto:
+email: "team@carpentries.org"
 
 # Sites.
 amy_site: "https://amy.software-carpentry.org/workshops"
@@ -30,16 +33,16 @@ carpentries_github: "https://github.com/carpentries"
 carpentries_pages: "https://carpentries.github.io"
 carpentries_site: "https://carpentries.org/"
 dc_site: "http://datacarpentry.org"
-example_repo: "https://github.com/swcarpentry/lesson-example"
-example_site: "https://swcarpentry.github.com/lesson-example"
+example_repo: "https://github.com/carpentries/lesson-example"
+example_site: "https://carpentries.github.io/lesson-example"
 lc_site: "https://librarycarpentry.github.io/"
 swc_github: "https://github.com/swcarpentry"
 swc_pages: "https://swcarpentry.github.io"
 swc_site: "https://software-carpentry.org"
-template_repo: "https://github.com/swcarpentry/styles"
-training_site: "https://swcarpentry.github.io/instructor-training"
-workshop_repo: "https://github.com/swcarpentry/workshop-template"
-workshop_site: "https://swcarpentry.github.io/workshop-template"
+template_repo: "https://github.com/carpentries/styles"
+training_site: "https://carpentries.github.io/instructor-training"
+workshop_repo: "https://github.com/carpentries/workshop-template"
+workshop_site: "https://carpentries.github.io/workshop-template"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="
@@ -61,17 +64,26 @@ collections:
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:
-      root: ..
+      root: .
+      layout: page
   - scope:
       path: ""
       type: episodes
     values:
+      root: ..
       layout: episode
+  - scope:
+      path: ""
+      type: extras
+    values:
+      root: ..
+      layout: page
 
 # Files and directories that are not to be copied.
 exclude:
   - Makefile
-  - bin
+  - bin/
+  - .Rproj.user/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge

--- a/bin/boilerplate/_episodes/01-introduction.md
+++ b/bin/boilerplate/_episodes/01-introduction.md
@@ -3,9 +3,12 @@ title: "Introduction"
 teaching: 0
 exercises: 0
 questions:
-- "Key question"
+- "Key question (FIXME)"
 objectives:
-- "First objective."
+- "First objective. (FIXME)"
 keypoints:
-- "First key point."
+- "First key point. (FIXME)"
 ---
+FIXME
+
+{% include links.md %}

--- a/bin/boilerplate/_extras/about.md
+++ b/bin/boilerplate/_extras/about.md
@@ -1,5 +1,5 @@
 ---
-layout: page
 title: About
 ---
 {% include carpentries.html %}
+{% include links.md %}

--- a/bin/boilerplate/_extras/discuss.md
+++ b/bin/boilerplate/_extras/discuss.md
@@ -1,5 +1,6 @@
 ---
-layout: page
 title: Discussion
 ---
 FIXME
+
+{% include links.md %}

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Figures
 ---
 <script>
@@ -37,3 +36,5 @@ Create anchor for each one of the episodes.
 {% for episode in site.episodes %}
 <article id="{{ episode.url }}"></article>
 {% endfor %}
+
+{% include links.md %}

--- a/bin/boilerplate/_extras/guide.md
+++ b/bin/boilerplate/_extras/guide.md
@@ -1,5 +1,6 @@
 ---
-layout: page
 title: "Instructor Notes"
 ---
 FIXME
+
+{% include links.md %}

--- a/bin/boilerplate/aio.md
+++ b/bin/boilerplate/aio.md
@@ -1,6 +1,4 @@
 ---
-layout: page
-root: .
 ---
 <script>
   window.onload = function() {

--- a/bin/boilerplate/index.md
+++ b/bin/boilerplate/index.md
@@ -1,6 +1,6 @@
 ---
 layout: lesson
-root: .
+root: .  # Is the only page that don't follow the partner /:path/index.html
 permalink: index.html  # Is the only page that don't follow the partner /:path/index.html
 ---
 FIXME: home page introduction
@@ -9,3 +9,5 @@ FIXME: home page introduction
 >
 > FIXME
 {: .prereq}
+
+{% include links.md %}

--- a/bin/boilerplate/reference.md
+++ b/bin/boilerplate/reference.md
@@ -1,8 +1,9 @@
 ---
 layout: reference
-root: .
 ---
 
 ## Glossary
 
 FIXME
+
+{% include links.md %}

--- a/bin/boilerplate/setup.md
+++ b/bin/boilerplate/setup.md
@@ -1,6 +1,7 @@
 ---
-layout: page
 title: Setup
-root: .
 ---
 FIXME
+
+
+{% include links.md %}

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Check lesson files and their contents.
@@ -26,7 +26,7 @@ SOURCE_DIRS = ['', '_episodes', '_extras']
 # specially. This list must include all the Markdown files listed in the
 # 'bin/initialize' script.
 REQUIRED_FILES = {
-    '%/CONDUCT.md': True,
+    '%/CODE_OF_CONDUCT.md': True,
     '%/CONTRIBUTING.md': False,
     '%/LICENSE.md': True,
     '%/README.md': False,
@@ -171,13 +171,18 @@ def check_config(reporter, source_dir):
     reporter.check_field(config_file, 'configuration',
                          config, 'kind', 'lesson')
     reporter.check_field(config_file, 'configuration',
-                         config, 'carpentry', ('swc', 'dc', 'lc'))
+                         config, 'carpentry', ('swc', 'dc', 'lc', 'cp'))
     reporter.check_field(config_file, 'configuration', config, 'title')
     reporter.check_field(config_file, 'configuration', config, 'email')
 
-    reporter.check({'values': {'root': '..'}} in config.get('defaults', []),
+    for defaults in [
+            {'values': {'root': '.', 'layout': 'page'}},
+            {'values': {'root': '..', 'layout': 'episode'}, 'scope': {'type': 'episodes', 'path': ''}},
+            {'values': {'root': '..', 'layout': 'page'}, 'scope': {'type': 'extras', 'path': ''}}
+            ]:
+        reporter.check(defaults in config.get('defaults', []),
                    'configuration',
-                   '"root" not set to ".." in configuration')
+                   '"root" not set to "." in configuration')
 
 
 def read_references(reporter, ref_path):
@@ -271,9 +276,9 @@ def create_checker(args, filename, info):
     for (pat, cls) in CHECKERS:
         if pat.search(filename):
             return cls(args, filename, **info)
+    return NotImplemented
 
-
-class CheckBase(object):
+class CheckBase:
     """Base class for checking Markdown files."""
 
     def __init__(self, args, filename, metadata, metadata_len, text, lines, doc):
@@ -508,7 +513,6 @@ class CheckGeneric(CheckBase):
 
     def __init__(self, args, filename, metadata, metadata_len, text, lines, doc):
         super().__init__(args, filename, metadata, metadata_len, text, lines, doc)
-        self.layout = 'page'
 
 
 CHECKERS = [
@@ -517,6 +521,7 @@ CHECKERS = [
     (re.compile(r'index\.md'), CheckIndex),
     (re.compile(r'reference\.md'), CheckReference),
     (re.compile(r'_episodes/.*\.md'), CheckEpisode),
+    (re.compile(r'aio\.md'), CheckNonJekyll),
     (re.compile(r'.*\.md'), CheckGeneric)
 ]
 

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Initialize a newly-created repository."""
 
@@ -11,8 +11,9 @@ BOILERPLATE = (
     '.travis.yml',
     'AUTHORS',
     'CITATION',
+    'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
-    'README.md'
+    'README.md',
     '_config.yml',
     '_episodes/01-introduction.md',
     '_extras/about.md',

--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Check repository settings.

--- a/bin/test_lesson_check.py
+++ b/bin/test_lesson_check.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import unittest
 
 import lesson_check

--- a/bin/util.py
+++ b/bin/util.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 import json
@@ -30,13 +29,11 @@ UNWANTED_FILES = [
 REPORTER_NOT_SET = []
 
 
-class Reporter(object):
+class Reporter:
     """Collect and report errors."""
 
     def __init__(self):
         """Constructor."""
-
-        super(Reporter, self).__init__()
         self.messages = []
 
     def check_field(self, filename, name, values, key, expected=REPORTER_NOT_SET):
@@ -65,36 +62,40 @@ class Reporter(object):
 
         self.messages.append((location, fmt.format(*args)))
 
+    @staticmethod
+    def pretty(item):
+        location, message = item
+        if isinstance(location, type(None)):
+            return message
+        elif isinstance(location, str):
+            return location + ': ' + message
+        elif isinstance(location, tuple):
+            return '{0}:{1}: '.format(*location) + message
+
+        print('Unknown item "{0}"'.format(item), file=sys.stderr)
+        return NotImplemented
+
+    @staticmethod
+    def key(item):
+        location, message = item
+        if isinstance(location, type(None)):
+            return ('', -1, message)
+        elif isinstance(location, str):
+            return (location, -1, message)
+        elif isinstance(location, tuple):
+            return (location[0], location[1], message)
+
+        print('Unknown item "{0}"'.format(item), file=sys.stderr)
+        return NotImplemented
+
     def report(self, stream=sys.stdout):
         """Report all messages in order."""
 
         if not self.messages:
             return
 
-        def pretty(item):
-            location, message = item
-            if isinstance(location, type(None)):
-                return message
-            elif isinstance(location, str):
-                return location + ': ' + message
-            elif isinstance(location, tuple):
-                return '{0}:{1}: '.format(*location) + message
-            else:
-                assert False, 'Unknown item "{0}"'.format(item)
-
-        def key(item):
-            location, message = item
-            if isinstance(location, type(None)):
-                return ('', -1, message)
-            elif isinstance(location, str):
-                return (location, -1, message)
-            elif isinstance(location, tuple):
-                return (location[0], location[1], message)
-            else:
-                assert False, 'Unknown item "{0}"'.format(item)
-
-        for m in sorted(self.messages, key=key):
-            print(pretty(m), file=stream)
+        for m in sorted(self.messages, key=self.key):
+            print(self.pretty(m), file=stream)
 
 
 def read_markdown(parser, path):

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''Check that a workshop's index.html metadata is valid.  See the
 docstrings on the checking functions for a summary of the checks.


### PR DESCRIPTION
This pull request brings the latest version of the template to this repository. Release notes are available from the styles GitHub Repository. See [v9.5.1](https://github.com/carpentries/styles/releases/tag/v9.5.1) and [v9.5.2](https://github.com/carpentries/styles/releases/tag/v9.5.2). Deployment progress tracked in carpentries/styles#302.
        