### PR TITLE
don't show schedule for workshop home page

### DIFF
--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -6,5 +6,3 @@ layout: base
 <article>
   {{ content }}
 </article>
-
-{% include syllabus.html %}


### PR DESCRIPTION
![screen shot 2018-10-23 at 3 38 11 pm](https://user-images.githubusercontent.com/19176319/47394972-b358f900-d6d9-11e8-806a-aa363f8eaa08.png)

Removes irrelevant schedule section from homepage. 