### PR TITLE
Update links to software

### DIFF
--- a/_includes/setup-data.md
+++ b/_includes/setup-data.md
@@ -1,7 +1,7 @@
 ## Data
 
-You can download all of the data used in this workshop by clicking
-[this download link](https://ndownloader.figshare.com/articles/6262019/versions/4). The file is 206 KB.
+You can [download all of the data used in this workshop](https://ndownloader.figshare.com/articles/6262019/versions/4)
+as a single zip file. The file is 206 KB.
 
 Clicking the download link will automatically download all of the files to your default download directory as a single compressed
 (`.zip`) file. To expand this file, double click the folder icon in your file navigator application (for Macs, this is the Finder

--- a/_includes/setup-openrefine.md
+++ b/_includes/setup-openrefine.md
@@ -1,17 +1,8 @@
 ### OpenRefine
 
-* OpenRefine is a Java program that runs on your local machine (not on the cloud). Although it displays in your browser, no web
-connection is needed and your data remains local. You need to have a ‘Java Runtime Environment’ (JRE) installed on your computer to run
-OpenRefine. If you don’t already have one installed then you can download and install from http://java.com by going to the site and
-clicking “Free Java Download”.
+OpenRefine can be downloaded from the [OpenRefine downloads]() page.
+When you download the version for your operating system, you are redirected to
+a page with initial instructions for running the software.
 
-* To install OpenRefine, go to their [download page](http://openrefine.org/download.html). From the download page, select either "Windows
-kit", "Mac kit", or "Linux kit" - depending on your operating system - and follow the instructions next to your download link. This
-lesson has been tested with all versions of OpenRefine up to the latest tested version, 3.2. **If you are using an older version, it is
-recommended you upgrade to the latest tested version.** After installing, you can delete the installer `.dmg` file.
-
-* You may get an error message: "OpenRefine.app can't be opened because it is from an unidentified developer." If you get this message,
-open your system preferences and click "Security & Privacy". You will see a message "OpenRefine.app was blocked from opening because it
-is from an unidentified developer." Click "Open Anyway" and "Yes". OpenRefine should open in your default web browser.
-
-* OpenRefine does not support Internet Explorer or Edge. Please use Firefox, Chrome or Safari instead.
+More detailed instructions are included in the [Setup section in the OpenRefine
+for Social Science Data](https://datacarpentry.org/openrefine-socialsci/#software).

--- a/_includes/setup-python.md
+++ b/_includes/setup-python.md
@@ -1,6 +1,6 @@
 ### Python and Jupyter Notebooks
 
-* [Python](http://python.org) is a popular language for
+* [Python](https://python.org) is a popular language for
 scientific computing, and great for general-purpose programming as
 well. For this workshop we use Python version 3.x.
 Installing all of its scientific packages individually can be

--- a/_includes/setup-r.md
+++ b/_includes/setup-r.md
@@ -1,5 +1,7 @@
 ### R and RStudio
 
+[download-rstudio]: https://posit.co/download/rstudio-desktop/#download
+
 * R and RStudio are separate downloads and installations. R is the
 underlying statistical computing environment, but using R alone is no
 fun. RStudio is a graphical integrated development environment (IDE) that makes
@@ -21,16 +23,19 @@ your operating system, and then follow the instructions to install
 >  which version of R you are running. Go on
 >  the [CRAN website](https://cran.r-project.org/bin/windows/base/) and check
 > whether a more recent version is available. If so, please download and install
-> it. You can [check here](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#How-do-I-UNinstall-R_003f) for
-> more information on how to remove old versions from your system if you wish to do so.
+> it.
+>
+> You can [uninstall older versions of R][uninstall-r] if you wish to do so.
 {: .solution}
+
+[uninstall-r]: https://cran.r-project.org/bin/windows/base/rw-FAQ.html#How-do-I-UNinstall-R_003f
 
 > ## If you don't have R and RStudio installed
 >
 > * Download R from
 >  the [CRAN website](https://cran.r-project.org/bin/windows/base/release.htm).
 > * Run the `.exe` file that was just downloaded
-> * Go to the [RStudio download page](https://www.rstudio.com/products/rstudio/download/#download)
+> * Go to the [RStudio download page][download-rstudio]
 > * Under *Installers* select **RStudio x.yy.zzz - Windows Vista/7/8/10** (where x, y, and z represent version numbers)
 > * Double click the file to install it
 > * Once it's installed, open RStudio to make sure it works and you don't get any
@@ -60,7 +65,7 @@ your operating system, and then follow the instructions to install
 > * Double click on the downloaded file to install R
 > * It is also a good idea to install [XQuartz](https://www.xquartz.org/) (needed
 >   by some packages)
-> * Go to the [RStudio download page](https://www.rstudio.com/products/rstudio/download/#download)
+> * Go to the [RStudio download page][download-rstudio]
 > * Under *Installers* select **RStudio x.yy.zzz - Mac OS X 10.6+ (64-bit)**
 >   (where x, y, and z represent version numbers)
 > * Double click the file to install RStudio
@@ -77,8 +82,7 @@ your operating system, and then follow the instructions to install
  `sudo apt-get install r-base`, and for Fedora `sudo yum install R`), but we
  don't recommend this approach as the versions provided by this are
  usually out of date. In any case, make sure you have at least R 3.2.
-* Go to the [RStudio download
-  page](https://www.rstudio.com/products/rstudio/download/#download)
+* Go to the [RStudio download page][download-rstudio]
 * Under *Installers* select the version that matches your distribution, and
    install it with your preferred method (e.g., with Debian/Ubuntu `sudo dpkg -i
    rstudio-x.yy.zzz-amd64.deb` at the terminal).

--- a/_includes/setup-spreadsheet.md
+++ b/_includes/setup-spreadsheet.md
@@ -5,6 +5,6 @@ Commands may differ a bit between programs, but the general ideas for thinking a
 we recommend using either Microsoft Excel (paid software) or LibreOffice (free and open source). Other spreadsheet programs may
 not have all of the features we will be exploring in this workshop.
 
-* To install LibreOffice, go to their [download page](https://www.libreoffice.org/download/download/). The website should
+* To install LibreOffice, first [download LibreOffice](https://www.libreoffice.org/download/download-libreoffice/). The website should
 automatically select the correct option for your operating system. Click the "Download" button. You will go to a page that asks about a
 donation, but you don’t need to make one. Your download should begin automatically. Once the installer is downloaded, double click on it (you may need to open your Downloads folder) and LibreOffice should install.

--- a/_includes/setup-sql.md
+++ b/_includes/setup-sql.md
@@ -1,11 +1,11 @@
 ## SQL
 
 * SQL is a specialized programming language used with databases.  We
-use a simple database manager called [SQLite](http://www.sqlite.org/)
-in our lessons. We will use the [DB Browser for SQLite](http://sqlitebrowser.org/) program,
+use a simple database manager called [SQLite](https://www.sqlite.org/)
+in our lessons. We will use the [DB Browser for SQLite](https://sqlitebrowser.org/) program,
 which is available for all major platforms.
 
-* To install the DB Browser, go to their [download page](http://sqlitebrowser.org/dl/) and choose the correct installer for
+* To install the DB Browser, first [download DB Browser for SQLite](https://sqlitebrowser.org/dl/) and choose the correct installer for
 your operating system. Once the installer is downloaded, double click on it (you may need to open your Downloads folder), follow
 any other instructions that appear, and
-DB Browser should install. After installing, you can delete the installer `.dmg` file.
+DB Browser should install. After installing, you can delete the installer file.

--- a/setup-python-workshop.md
+++ b/setup-python-workshop.md
@@ -12,10 +12,10 @@ title: Setup for Python workshop
 
 | Software | Install | Manual | Available for | Description |
 | -------- | ------------ | ------ | ------------- | ----------- |
-| Spreadsheet program | [Link](https://www.libreoffice.org/download/download/) | [Link](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
-| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows |
+| Spreadsheet program | [Download LibreOffice](https://www.libreoffice.org/download/download/) | [LibreOffice documentation](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
+| OpenRefine |[Download OpenRefine](https://openrefine.org/download.html) | [OpenRefine documentation](https://openrefine.org/docs) | Linux, MacOS, Windows |
 | Python | See install instructions below. |  | Linux, MacOS, Windows | |
-| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | | |
+| DB Browser for SQLite | [Download DB Browser for SQLite](https://sqlitebrowser.org/dl/) | | Linux, MacOS, Windows | |
 
 {% include setup-spreadsheet.md %}
 

--- a/setup-r-workshop.md
+++ b/setup-r-workshop.md
@@ -12,11 +12,11 @@ title: Setup for R workshop
 
 | Software | Install | Manual | Available for | Description |
 | -------- | ------------ | ------ | ------------- | ----------- |
-| Spreadsheet program | [Link](https://www.libreoffice.org/download/download/) | [Link](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
-| OpenRefine |[Link](http://openrefine.org/download.html) | [Link](http://openrefine.org/documentation.html) | Linux, MacOS, Windows |
+| Spreadsheet program | [Download LibreOffice](https://www.libreoffice.org/download/download-libreoffice/) | [LibreOffice documentation](https://documentation.libreoffice.org/en/english-documentation/) | Linux, MacOS, Windows | Spreadsheet program for organizing tabular data. |
+| OpenRefine |[Download OpenRefine](https://openrefine.org/download.html) | [OpenRefine documentation](https://openrefine.org/docs) | Linux, MacOS, Windows |
 | R | See install instructions below. | | Linux, MacOS, Windows | |
-| RStudio | [Link](https://www.rstudio.com/products/rstudio/download/#download) | [Cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf) | Linux, MacOS, Windows| |
-| SQLite Browser | [Link](http://sqlitebrowser.org/dl/) | | |
+| RStudio | [Download RStudio](https://posit.co/download/rstudio-desktop/#download) | [RStudio Cheatsheet](https://raw.githubusercontent.com/rstudio/cheatsheets/main/rstudio-ide.pdf) | Linux, MacOS, Windows| |
+| DB Browser for SQLite | [Download DB Browser for SQLite](https://sqlitebrowser.org/dl/) | Linux, MacOS, Windows | |
 
 
 

--- a/setup.md
+++ b/setup.md
@@ -9,6 +9,6 @@ title: Setup
 ## Setup instructions for your workshop
 
 * If you are attending a workshop where Python will be taught,
-  follow [these setup instructions]({{ site.baseurl }}{% link setup-python-workshop.md %})
+  follow the [Python workshop setup instructions]({{ site.baseurl }}{% link setup-python-workshop.md %}).
 * If you are attentind a workshop where R will be taught,
-  follow [these setup instructions]({{ site.baseurl }}{% link setup-r-workshop.md%})
+  follow the [R workshop setup instructions]({{ site.baseurl }}{% link setup-r-workshop.md %}).


### PR DESCRIPTION
This fixes #54 and also updates all other links to software throughout the workshop overview.

Note that I removed most of the instructions for installing OpenRefine, because they are more up-to-date in the lesson's instructions. In case the instructions that OpenRefine provides on the download page are insufficient, learners are referred to the lesson (which I maintain).

This also fixes #52.