### PR TITLE
Remove schedule from landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,9 +51,9 @@ start_time: 0
 
 # Specify that things in the episodes collection should be output.
 collections:
-  episodes:
-    output: true
-    permalink: /:path/
+#  episodes:
+#    output: true
+#    permalink: /:path/
   extras:
     output: true
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
-layout: lesson
-root: .
+
 ---
 
 Data Carpentry’s aim is to teach researchers basic concepts, skills, and tools


### PR DESCRIPTION
Fixes #55 by removing the Schedule section from the landing page, and the Episodes dropdown from the top menu.