### PR TITLE
Fix link to data description, use datacarpentry.org

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ smartphone. The results are then sent back to a central server. The server can
 be used to produce the collected data in both JSON and CSV formats. We will
 use a sample of the collected data in CSV format throughout this workshop.
 
-[More information on this dataset](instructors/data.md)
+[More information on this dataset](learners/data.md)
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -64,15 +64,15 @@ This curriculum is currently available using R as the main programming language.
 
 | Lesson | Overview                                                                                                                                                         | 
 | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Data Organization in Spreadsheets](https://datacarpentry.github.io/spreadsheets-socialsci/)       | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. | 
-| [Data Cleaning with OpenRefine](https://datacarpentry.github.io/openrefine-socialsci/)       | Explore, summarize, and clean tabular data reproducibly.                                                                                                         | 
-| [Data Analysis and Visualisation with R](https://datacarpentry.github.io/r-socialsci)       | Import data into R, calculate summary statistics, and create publication-quality graphics.                                                                       | 
+| [Data Organization in Spreadsheets](https://datacarpentry.org/spreadsheets-socialsci/)       | Learn how to organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications. | 
+| [Data Cleaning with OpenRefine](https://datacarpentry.org/openrefine-socialsci/)       | Explore, summarize, and clean tabular data reproducibly.                                                                                                         | 
+| [Data Analysis and Visualisation with R](https://datacarpentry.org/r-socialsci)       | Import data into R, calculate summary statistics, and create publication-quality graphics.                                                                       | 
 
 # Workshop Materials in Development
 
 | Lesson | Overview                                                                                                                                                         | 
 | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [Data Analysis and Visualisation with Python](https://datacarpentry.github.io/python-socialsci/)       | Import data into Python, calculate summary statistics, and create publication-quality graphics.                                                                  | 
-| [Data Management with SQL](https://datacarpentry.github.io/sql-socialsci/)       | Extract information from relational databases.                                                                                                                   | 
+| [Data Analysis and Visualisation with Python](https://datacarpentry.org/python-socialsci/)       | Import data into Python, calculate summary statistics, and create publication-quality graphics.                                                                  | 
+| [Data Management with SQL](https://datacarpentry.org/sql-socialsci/)       | Extract information from relational databases.                                                                                                                   | 
 
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
Does not close any issues. I noticed that a warning was generated during the validation step in the workflow for #62 about a broken link.

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
The link to the description of the data pointed to `instructors` instead of `learners`. This should fix the broken link warning and hopefully make the workflow pass.
I also noticed thet use of `datacarpentry.github.io` to link to DC lessons instead of `datacarpentry.org`. I updated them too.

_If any relevant discussions have taken place elsewhere, please provide links to these._
n/a
